### PR TITLE
Add duotrio_pc function

### DIFF
--- a/senspy/__init__.py
+++ b/senspy/__init__.py
@@ -2,7 +2,7 @@
 
 from .links import psyfun, psyinv, psyderiv, rescale
 from .models import BetaBinomial
-from .discrimination import two_afc
+from .discrimination import two_afc, duotrio_pc
 from .power import beta_binomial_power
 from .plotting import plot_psychometric
 from .utils import has_jax, version
@@ -14,6 +14,7 @@ __all__ = [
     "rescale",
     "BetaBinomial",
     "two_afc",
+    "duotrio_pc",
     "beta_binomial_power",
     "plot_psychometric",
     "has_jax",

--- a/senspy/discrimination.py
+++ b/senspy/discrimination.py
@@ -1,8 +1,17 @@
 import numpy as np
 from scipy.stats import norm
 
-__all__ = ["two_afc"]
+__all__ = ["two_afc", "duotrio_pc"]
 
 def two_afc(dprime: float) -> float:
     """Proportion correct in a 2-AFC task for a given d-prime."""
     return norm.cdf(dprime / np.sqrt(2))
+
+
+def duotrio_pc(dprime: float) -> float:
+    """Proportion correct in a duo-trio test for a given d-prime."""
+    if dprime <= 0:
+        return 0.5
+    a = norm.cdf(dprime / np.sqrt(2.0))
+    b = norm.cdf(dprime / np.sqrt(6.0))
+    return 1 - a - b + 2 * a * b

--- a/tests/test_discrimination.py
+++ b/tests/test_discrimination.py
@@ -1,0 +1,12 @@
+import numpy as np
+from senspy import duotrio_pc
+
+
+def test_duotrio_half_at_zero():
+    assert duotrio_pc(0.0) == 0.5
+
+
+def test_duotrio_monotonic():
+    low = duotrio_pc(0.1)
+    high = duotrio_pc(1.0)
+    assert low < high < 1.0


### PR DESCRIPTION
## Summary
- expand discrimination utilities with `duotrio_pc`
- expose the new function in the package API
- add initial tests for `duotrio_pc`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*