### PR TITLE
Add discrim_2afc function

### DIFF
--- a/senspy/__init__.py
+++ b/senspy/__init__.py
@@ -2,7 +2,7 @@
 
 from .links import psyfun, psyinv, psyderiv, rescale
 from .models import BetaBinomial
-from .discrimination import two_afc
+from .discrimination import two_afc, duotrio_pc, discrim_2afc
 from .power import beta_binomial_power
 from .plotting import plot_psychometric
 from .utils import has_jax, version
@@ -14,6 +14,8 @@ __all__ = [
     "rescale",
     "BetaBinomial",
     "two_afc",
+    "duotrio_pc",
+    "discrim_2afc",
     "beta_binomial_power",
     "plot_psychometric",
     "has_jax",

--- a/senspy/discrimination.py
+++ b/senspy/discrimination.py
@@ -1,8 +1,32 @@
 import numpy as np
 from scipy.stats import norm
 
-__all__ = ["two_afc"]
+__all__ = ["two_afc", "duotrio_pc", "discrim_2afc"]
 
 def two_afc(dprime: float) -> float:
     """Proportion correct in a 2-AFC task for a given d-prime."""
     return norm.cdf(dprime / np.sqrt(2))
+
+
+def duotrio_pc(dprime: float) -> float:
+    """Proportion correct in a duo-trio test for a given d-prime."""
+    if dprime <= 0:
+        return 0.5
+    a = norm.cdf(dprime / np.sqrt(2.0))
+    b = norm.cdf(dprime / np.sqrt(6.0))
+    return 1 - a - b + 2 * a * b
+
+
+def discrim_2afc(correct: int, total: int) -> dict:
+    """Estimate d-prime and standard error for a 2-AFC test."""
+    if total <= 0:
+        raise ValueError("total must be positive")
+    if correct < 0 or correct > total:
+        raise ValueError("correct must be between 0 and total")
+
+    pc = correct / total
+    dp = np.sqrt(2.0) * norm.ppf(pc)
+    se_pc = np.sqrt(pc * (1 - pc) / total)
+    deriv = norm.pdf(dp / np.sqrt(2.0)) / np.sqrt(2.0)
+    se_dp = se_pc / deriv
+    return {"d_prime": dp, "se": se_dp}

--- a/tests/test_discrimination.py
+++ b/tests/test_discrimination.py
@@ -1,0 +1,18 @@
+import numpy as np
+from senspy import duotrio_pc, discrim_2afc
+
+
+def test_duotrio_half_at_zero():
+    assert duotrio_pc(0.0) == 0.5
+
+
+def test_duotrio_monotonic():
+    low = duotrio_pc(0.1)
+    high = duotrio_pc(1.0)
+    assert low < high < 1.0
+
+
+def test_discrim_2afc_estimates():
+    res = discrim_2afc(correct=25, total=50)
+    assert res["d_prime"] > 0
+    assert res["se"] > 0


### PR DESCRIPTION
## Summary
- implement `discrim_2afc` to estimate d-prime and standard error for 2-AFC data
- re-export the function through the package API
- extend discrimination tests for the new utility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*