### PR TITLE
Expand discrimination utilities

### DIFF
--- a/senspy/__init__.py
+++ b/senspy/__init__.py
@@ -2,7 +2,14 @@
 
 from .links import psyfun, psyinv, psyderiv, rescale
 from .models import BetaBinomial
-from .discrimination import two_afc
+from .discrimination import (
+    two_afc,
+    duotrio_pc,
+    get_pguess,
+    pc2pd,
+    pd2pc,
+    discrim_2afc,
+)
 from .power import beta_binomial_power
 from .plotting import plot_psychometric
 from .utils import has_jax, version
@@ -14,6 +21,11 @@ __all__ = [
     "rescale",
     "BetaBinomial",
     "two_afc",
+    "duotrio_pc",
+    "get_pguess",
+    "pc2pd",
+    "pd2pc",
+    "discrim_2afc",
     "beta_binomial_power",
     "plot_psychometric",
     "has_jax",

--- a/senspy/discrimination.py
+++ b/senspy/discrimination.py
@@ -1,8 +1,85 @@
 import numpy as np
 from scipy.stats import norm
 
-__all__ = ["two_afc"]
+__all__ = [
+    "two_afc",
+    "duotrio_pc",
+    "get_pguess",
+    "pc2pd",
+    "pd2pc",
+    "discrim_2afc",
+]
 
 def two_afc(dprime: float) -> float:
     """Proportion correct in a 2-AFC task for a given d-prime."""
     return norm.cdf(dprime / np.sqrt(2))
+
+
+def duotrio_pc(dprime: float) -> float:
+    """Proportion correct in a duo-trio test for a given d-prime."""
+    if dprime <= 0:
+        return 0.5
+    a = norm.cdf(dprime / np.sqrt(2.0))
+    b = norm.cdf(dprime / np.sqrt(6.0))
+    return 1 - a - b + 2 * a * b
+
+
+def get_pguess(method: str = "duotrio", double: bool = False) -> float:
+    """Return the chance performance level for a protocol."""
+    method = method.lower()
+    base = {
+        "duotrio": 1 / 2,
+        "twoafc": 1 / 2,
+        "threeafc": 1 / 3,
+        "triangle": 1 / 3,
+        "tetrad": 1 / 3,
+        "hexad": 1 / 10,
+        "twofive": 1 / 10,
+        "twofivef": 2 / 5,
+    }.get(method)
+    if base is None:
+        raise ValueError(f"Unknown method: {method}")
+    return base ** 2 if double else base
+
+
+def pc2pd(pc: float, pguess: float) -> float:
+    """Convert proportion correct to proportion discriminated."""
+    if not (0 <= pguess <= 1):
+        raise ValueError("pguess must be between 0 and 1")
+    if not (0 <= pc <= 1):
+        raise ValueError("pc must be between 0 and 1")
+    pd = (pc - pguess) / (1 - pguess)
+    return max(pd, 0.0)
+
+
+def pd2pc(pd: float, pguess: float) -> float:
+    """Convert proportion discriminated to proportion correct."""
+    if not (0 <= pguess <= 1):
+        raise ValueError("pguess must be between 0 and 1")
+    if not (0 <= pd <= 1):
+        raise ValueError("pd must be between 0 and 1")
+    return pguess + pd * (1 - pguess)
+
+
+def discrim_2afc(correct: int, total: int) -> dict:
+    """Estimate d-prime from 2-AFC counts.
+
+    Parameters
+    ----------
+    correct : int
+        Number of correct responses.
+    total : int
+        Total number of trials.
+    Returns
+    -------
+    dict
+        Dictionary with keys ``d_prime`` and ``se``.
+    """
+    if total <= 0 or correct < 0 or correct > total:
+        raise ValueError("invalid count data")
+    pc = correct / total
+    dprime = np.sqrt(2.0) * norm.ppf(pc)
+    # derivative of pc->dprime mapping
+    deriv = np.sqrt(2.0) / norm.pdf(norm.ppf(pc))
+    se = np.sqrt(pc * (1 - pc) / total) * deriv
+    return {"d_prime": dprime, "se": se}

--- a/tests/test_discrimination.py
+++ b/tests/test_discrimination.py
@@ -1,0 +1,35 @@
+import numpy as np
+from senspy import (
+    duotrio_pc,
+    get_pguess,
+    pc2pd,
+    pd2pc,
+    discrim_2afc,
+)
+
+
+def test_duotrio_half_at_zero():
+    assert duotrio_pc(0.0) == 0.5
+
+
+def test_duotrio_monotonic():
+    low = duotrio_pc(0.1)
+    high = duotrio_pc(1.0)
+    assert low < high < 1.0
+
+
+def test_pc_pd_roundtrip():
+    pg = get_pguess("twoafc")
+    pc = 0.75
+    pd = pc2pd(pc, pg)
+    pc_back = pd2pc(pd, pg)
+    assert np.isclose(pc, pc_back)
+
+
+def test_get_pguess_double():
+    assert np.isclose(get_pguess("twoafc", double=True), 0.25)
+
+
+def test_discrim_2afc_positive():
+    res = discrim_2afc(correct=30, total=40)
+    assert res["d_prime"] > 0 and res["se"] > 0


### PR DESCRIPTION
## Summary
- expose more discrimination helpers in the package API
- implement conversion utilities (`get_pguess`, `pc2pd`, `pd2pc`)
- add `discrim_2afc` for d-prime estimation
- expand tests to cover the new helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
